### PR TITLE
Fix modelApiKey Storage in Record Links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "datocms-plugin-better-linking",
-	"version": "0.2.1",
+	"version": "0.2.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "datocms-plugin-better-linking",
-			"version": "0.2.1",
+			"version": "0.2.3",
 			"license": "ISC",
 			"dependencies": {
 				"@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"private": false,
 	"name": "datocms-plugin-better-linking",
 	"homepage": "https://github.com/ColinDorr/datocms-plugin-better-linking",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"description": "This datoCMS plugin enables a custom UI, to have better controll over your record, assets, urls, telephone or email links",
 	"engines": {
 		"node": ">=20.0.0"

--- a/src/components/fields/FieldRecord.tsx
+++ b/src/components/fields/FieldRecord.tsx
@@ -11,6 +11,7 @@ type FieldSettings = {
 	url?: string | undefined;
 	cms_url: string | undefined;
 	status: string | undefined;
+	modelApiKey?: string | undefined;
 };
 
 const resetObject: FieldSettings = {
@@ -20,6 +21,7 @@ const resetObject: FieldSettings = {
 	url: undefined,
 	cms_url: undefined,
 	status: undefined,
+	modelApiKey: undefined,
 };
 
 type Props = {
@@ -82,8 +84,27 @@ const FieldRecord: React.FC<Props> = ({
 		const status = record?.meta?.status || null;
 		const url = slug;
 
+		// Get model API key from the item type relationship
+		let modelApiKey: string | undefined = undefined;
+		if (record?.relationships?.item_type?.data?.id) {
+			const itemTypeId = record.relationships.item_type.data.id;
+
+			const matchingItemType = itemTypes.find(
+				(itemType: any) => itemType.id === itemTypeId,
+			);
+
+			// Check if we can get the API key directly from the record's item_type data
+			if (record?.relationships?.item_type?.data?.attributes?.api_key) {
+				modelApiKey = String(
+					record.relationships.item_type.data.attributes.api_key,
+				);
+			} else if (matchingItemType?.api_key) {
+				modelApiKey = String(matchingItemType.api_key);
+			}
+		}
+
 		if (id && title && cms_url && slug && status && url) {
-			recordData = { id, title, cms_url, slug, status, url };
+			recordData = { id, title, cms_url, slug, status, url, modelApiKey };
 		} else if (record !== null) {
 			const errors = [];
 			if (id === null) {

--- a/src/entrypoints/ContentConfigScreen.tsx
+++ b/src/entrypoints/ContentConfigScreen.tsx
@@ -147,36 +147,66 @@ export default function ContentConigScreen({ ctx }: PropTypes) {
 
 	const getRecordModel = (source: any) => {
 		const url = source?.cms_url || "";
-		const match = url.match(/item_types\/(\d+)/);
+		// Updated regex to match alphanumeric item type IDs with dashes and underscores
+		const match = url.match(/item_types\/([A-Za-z0-9_-]+)/);
 		const recordItemType = match ? match[1] : null;
 
 		if (!recordItemType) {
 			return null;
 		}
 
-		return (
-			itemTypes.filter(
-				(itemType: any) => itemType.id === recordItemType,
-			)[0] ?? null
-		);
+		const matchingItemType =
+			itemTypes.find((itemType: any) => itemType.id === recordItemType) ||
+			null;
+
+		return matchingItemType;
 	};
 
 	const getRecordModelDetails = (sourceRecord: any) => {
 		if (!sourceRecord?.cms_url) {
 			return null;
 		}
+
 		const recordModel = getRecordModel(sourceRecord);
+
+		// Ensure modelApiKey is set
+		let apiKey = undefined;
+		if (recordModel && recordModel.api_key) {
+			apiKey = String(recordModel.api_key);
+		} else if (
+			recordModel &&
+			recordModel.attributes &&
+			recordModel.attributes.api_key
+		) {
+			apiKey = String(recordModel.attributes.api_key);
+		} else {
+			// Fallback: try direct extraction from URL if needed
+			const directMatch = sourceRecord.cms_url.match(
+				/item_types\/([A-Za-z0-9_-]+)/,
+			);
+			if (directMatch && directMatch[1]) {
+				const directItemTypeId = directMatch[1];
+				const directMatchingItemType = itemTypes.find(
+					(it: any) => it.id === directItemTypeId,
+				);
+				if (directMatchingItemType && directMatchingItemType.api_key) {
+					apiKey = String(directMatchingItemType.api_key);
+				}
+			}
+		}
+
 		return {
 			...sourceRecord,
-			modelApiKey: recordModel?.api_key ? recordModel.api_key : undefined,
-			modelData: recordModel?.api_key
-				? {
-						id: recordModel?.id,
-						api_key: recordModel?.api_key,
-						label: recordModel?.label,
-						type: recordModel?.type,
-					}
-				: undefined,
+			modelApiKey: apiKey,
+			modelData:
+				apiKey && recordModel
+					? {
+							id: recordModel?.id,
+							api_key: apiKey,
+							label: recordModel?.label,
+							type: recordModel?.type,
+						}
+					: undefined,
 		};
 	};
 
@@ -256,7 +286,9 @@ export default function ContentConigScreen({ ctx }: PropTypes) {
 	// Update field setting on change
 	const updateContentSettings = async (valueObject: any) => {
 		storedData = { ...storedData, ...contentSettings, ...valueObject };
-		if (storedData?.record) {
+
+		// Process record to ensure modelApiKey is available
+		if (storedData?.record && Object.keys(storedData.record).length > 0) {
 			const record = getRecordModelDetails(storedData.record);
 			if (record) {
 				storedData.record = { ...record };
@@ -275,10 +307,19 @@ export default function ContentConigScreen({ ctx }: PropTypes) {
 			email: selectedType === "email" ? storedData.email : defaultEmail,
 		};
 
+		// Ensure modelApiKey is up-to-date
+		if (selectedType === "record" && storedData?.record?.id) {
+			storedData.record =
+				getRecordModelDetails(storedData.record) || storedData.record;
+		}
+
 		const formatted = {
 			isValid: false,
 			type: selectedType,
-			modelApiKey: storedData?.record?.modelApiKey ?? undefined,
+			modelApiKey:
+				selectedType === "record"
+					? storedData?.record?.modelApiKey
+					: undefined,
 			text: getText(storedData, selectedType),
 			ariaLabel:
 				storedData.aria_label ?? getText(storedData, selectedType),


### PR DESCRIPTION
## Issue

When a link is set to a record type, the modelApiKey was not being saved in the formatted object, which prevented proper link association with record models.

## Changes

- Updated regex pattern to correctly extract alphanumeric item type IDs from URLs
- Enhanced modelApiKey extraction with multiple fallback methods
- Ensured modelApiKey is included in both record and formatted objects

## Why

This fix ensures that links to records properly store the model type they belong to, which is essential for features that need to identify record types in linked content.

Related to #8 