### PR TITLE
Fix: Truncate long record titles in link field to prevent layout overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "datocms-plugin-better-linking",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "datocms-plugin-better-linking",
-			"version": "0.2.3",
+			"version": "0.2.4",
 			"license": "ISC",
 			"dependencies": {
 				"@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/src/styles/styles.ContentConfigScreen.module.css
+++ b/src/styles/styles.ContentConfigScreen.module.css
@@ -16,6 +16,7 @@
 
 .link-field > * {
     width: 100%;
+    min-width: 0;
     margin: 0;
 }
 .link-field > *:nth-of-type(1){

--- a/src/styles/styles.FieldRecordAsset.module.css
+++ b/src/styles/styles.FieldRecordAsset.module.css
@@ -2,9 +2,11 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    min-width: 0;
     gap: 0;
 }
-.field__selection-group > * {
+
+.field__selection-group>* {
     margin: 0;
 }
 
@@ -22,16 +24,17 @@
     width: 100%;
     gap: var(--spacing-m);
 }
-.field__selection-group__content > * {
+
+.field__selection-group__content>* {
     margin: 0;
 }
-.field__selection-group__content > *:nth-of-type(1){
-    width: 100%;
+
+.field__selection-group__content>*:nth-of-type(1) {
+    min-width: 0;
     flex: 1;
 }
 
 .field__selection-group__result {
-    width: 100%;
     text-align: left;
     border: 1px solid var(--border-color);
     border-radius: 0;
@@ -43,31 +46,42 @@
     resize: none;
     transition: border .2s var(--material-ease);
     background: white;
-    width: 100%;
+    min-width: 0;
+    overflow: hidden;
 }
-.field__selection-group__result > * {
+
+.field__selection-group__result>* {
     display: flex;
     flex-direction: row;
     align-items: center;
     gap: var(--spacing-m);
+    min-width: 0;
+    overflow: hidden;
 }
+
 .field__selection-group__result .published,
 .field__selection-group__result .updated {
     width: 12px;
     height: 12px;
+    flex-shrink: 0;
     display: block;
     overflow: hidden;
     background: var(--notice-color);
     border-radius: 50%;
     color: transparent;
 }
+
 .field__selection-group__result .updated {
     background: var(--warning-color);
 }
+
 .field__selection-group__result-title {
     color: black;
     font-size: var(--font-size-l);
-    font-weight: 400;  
+    font-weight: 400;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .field__selection-group__button {


### PR DESCRIPTION
**TL;DR** CSS Fix: Longer record titles caused overflowing. 

---

**TL;DR - Fix: Truncate long record titles in link field to prevent layout overflow**

---

## Description 

### Summary

Long record titles in the **Record** selector caused horizontal overflow: the title row grew past the grid column, squeezed the Type/Styling selects, and pushed the delete control and adjacent columns out of alignment.

### Root cause

The selected-record UI is built from nested **flex** and **grid** layouts. Flex/grid items default to `min-width: auto`, so they won’t shrink below their content width unless ancestors explicitly allow it. The title text had no reliable truncation chain from the grid cell down to the text node, so the row expanded instead of ellipsizing.

### Solution

- Apply **`min-width: 0`** along the layout chain (grid column children → record block → inner flex row) so columns can shrink within the grid.
- Constrain the record **button** and its inner flex wrapper with **`overflow: hidden`** where needed.
- Truncate the title with **`text-overflow: ellipsis`** and **`white-space: nowrap`** on the title span.
- Keep the status indicator from collapsing with **`flex-shrink: 0`** on the dot.

### Files changed

- `src/styles/styles.FieldRecordAsset.module.css` — record selection row and title truncation  
- `src/styles/styles.ContentConfigScreen.module.css` — grid column children (`min-width: 0`)

### How to verify

1. `npm run dev`, plugin URL in DatoCMS field settings → `http://localhost:3000`  
2. Choose **Record** and pick an item with a **very long title**  
3. Confirm: three columns stay aligned; title shows **ellipsis**; delete button stays visible; Type/Styling selects stay readable  

### Screenshots

| Before | After |
|--------|--------|
| <img width="800" height="327" alt="long title overflows / layout breaks" src="https://github.com/user-attachments/assets/e229ea6e-5359-4698-85c3-ac110c16286f" />| <img width="774" height="237" alt="title truncated with ellipsis, layout stable" src="https://github.com/user-attachments/assets/18caa67a-9e58-4fbd-a743-fc47acad2634" />|
