### PR TITLE
Don't save entire itemType metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"private": false,
 	"name": "datocms-plugin-better-linking",
 	"homepage": "https://github.com/ColinDorr/datocms-plugin-better-linking",
-	"version": "0.2.6",
+	"version": "0.2.7",
 	"description": "This datoCMS plugin enables a custom UI, to have better controll over your record, assets, urls, telephone or email links",
 	"engines": {
 		"node": ">=20.0.0"

--- a/src/components/controlls/LinkSettings.tsx
+++ b/src/components/controlls/LinkSettings.tsx
@@ -98,7 +98,6 @@ const LinkSetting: React.FC<PropTypes> = ({ ctx, configType }) => {
 	const itemTypes: LinkType[] = Object.values(ctx?.itemTypes)
 		.filter((type: any) => !type.attributes.modular_block)
 		.map((value: any) => ({
-			...value,
 			label: value.attributes.name,
 			api_key: value.attributes.api_key,
 			value: value.id,


### PR DESCRIPTION
Fix https://github.com/ColinDorr/datocms-plugin-better-linking/issues/14

When specifying allowable models to link to, we don't need their full `itemType` metadata, just their label, api_key, and ID. Otherwise, it will quickly bloat our plugin parameters past the allowable max size (10 KB) when we have more than a few models selected.

## Before

Every `itemType` had its full metadata saved into the params

https://github.com/user-attachments/assets/7d2f1e58-139b-4ff3-b554-3011a00d0927

## After
Every `itemType` only saves the necessary metadata (`label`, `api_key`, and `id`), not the unnecessary stuff

![Example Model  Models  better-linking  DatoCMS — Private Browsing - 2026-03-30 12-01-48 PM](https://github.com/user-attachments/assets/db772129-a9ed-4b35-b83a-2ee8236b2c62)
