### PR TITLE
fix: normalize itemTypes lookup so model API key resolution works with both compact and legacy shapes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "datocms-plugin-better-linking",
-	"version": "0.2.6",
+	"version": "0.2.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "datocms-plugin-better-linking",
-			"version": "0.2.6",
+			"version": "0.2.8",
 			"license": "ISC",
 			"dependencies": {
 				"@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"private": false,
 	"name": "datocms-plugin-better-linking",
 	"homepage": "https://github.com/ColinDorr/datocms-plugin-better-linking",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "This datoCMS plugin enables a custom UI, to have better controll over your record, assets, urls, telephone or email links",
 	"engines": {
 		"node": ">=20.0.0"

--- a/src/components/fields/FieldRecord.tsx
+++ b/src/components/fields/FieldRecord.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { FieldGroup, Button, SelectField } from "datocms-react-ui";
+import { findItemTypeById } from "./../../utils/helpers";
 import styles from "./../../styles/styles.FieldRecordAsset.module.css";
 
 type LinkType = { label: string; api_key?: string; value: string };
@@ -84,14 +85,11 @@ const FieldRecord: React.FC<Props> = ({
 		const status = record?.meta?.status || null;
 		const url = slug;
 
-		// Get model API key from the item type relationship
+		// Get model API key from the item type relationship or allowed item types
 		let modelApiKey: string | undefined = undefined;
 		if (record?.relationships?.item_type?.data?.id) {
 			const itemTypeId = record.relationships.item_type.data.id;
-
-			const matchingItemType = itemTypes.find(
-				(itemType: any) => itemType.id === itemTypeId,
-			);
+			const matchingItemType = findItemTypeById(itemTypes, itemTypeId);
 
 			// Check if we can get the API key directly from the record's item_type data
 			if (record?.relationships?.item_type?.data?.attributes?.api_key) {

--- a/src/entrypoints/ContentConfigScreen.tsx
+++ b/src/entrypoints/ContentConfigScreen.tsx
@@ -17,7 +17,7 @@ import FieldUrl from "./../components/fields/FieldUrl";
 
 import styles from "./../styles/styles.ContentConfigScreen.module.css";
 
-const { getCtxParams, getDefaultValue } = Helpers();
+const { getCtxParams, getDefaultValue, findItemTypeById } = Helpers();
 
 type PropTypes = {
 	ctx: any;
@@ -155,11 +155,7 @@ export default function ContentConigScreen({ ctx }: PropTypes) {
 			return null;
 		}
 
-		const matchingItemType =
-			itemTypes.find((itemType: any) => itemType.id === recordItemType) ||
-			null;
-
-		return matchingItemType;
+		return findItemTypeById(itemTypes, recordItemType);
 	};
 
 	const getRecordModelDetails = (sourceRecord: any) => {
@@ -169,30 +165,10 @@ export default function ContentConigScreen({ ctx }: PropTypes) {
 
 		const recordModel = getRecordModel(sourceRecord);
 
-		// Ensure modelApiKey is set
+		// Ensure modelApiKey is set (compact itemTypes use `value` as id, not `id`)
 		let apiKey = undefined;
-		if (recordModel && recordModel.api_key) {
+		if (recordModel?.api_key) {
 			apiKey = String(recordModel.api_key);
-		} else if (
-			recordModel &&
-			recordModel.attributes &&
-			recordModel.attributes.api_key
-		) {
-			apiKey = String(recordModel.attributes.api_key);
-		} else {
-			// Fallback: try direct extraction from URL if needed
-			const directMatch = sourceRecord.cms_url.match(
-				/item_types\/([A-Za-z0-9_-]+)/,
-			);
-			if (directMatch && directMatch[1]) {
-				const directItemTypeId = directMatch[1];
-				const directMatchingItemType = itemTypes.find(
-					(it: any) => it.id === directItemTypeId,
-				);
-				if (directMatchingItemType && directMatchingItemType.api_key) {
-					apiKey = String(directMatchingItemType.api_key);
-				}
-			}
 		}
 
 		return {
@@ -201,10 +177,10 @@ export default function ContentConigScreen({ ctx }: PropTypes) {
 			modelData:
 				apiKey && recordModel
 					? {
-							id: recordModel?.id,
+							id: recordModel.id,
 							api_key: apiKey,
-							label: recordModel?.label,
-							type: recordModel?.type,
+							label: recordModel.label,
+							type: recordModel.type,
 						}
 					: undefined,
 		};

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -1,3 +1,59 @@
+/**
+ * Plugin settings store "allowed record models" as compact select options
+ * `{ label, api_key?, value }` (`value` is the item type id). Older saves may
+ * still contain full Dato item type objects with `id` and `attributes`.
+ */
+export type NormalizedItemType = {
+	id: string;
+	api_key?: string;
+	label?: string;
+	type?: string;
+};
+
+export function normalizeItemTypeEntry(itemType: any): NormalizedItemType | null {
+	if (!itemType) {
+		return null;
+	}
+
+	// Compact shape from LinkSettings (post 0.2.7): { label, api_key?, value }
+	if (itemType.value !== undefined && itemType.value !== null) {
+		return {
+			id: String(itemType.value),
+			api_key: itemType.api_key,
+			label: itemType.label,
+		};
+	}
+
+	// Full Dato item type resource (legacy saved params)
+	if (itemType.id) {
+		return {
+			id: String(itemType.id),
+			api_key: itemType.api_key ?? itemType.attributes?.api_key,
+			label: itemType.label ?? itemType.attributes?.name,
+			type: itemType.type ?? itemType.attributes?.kind,
+		};
+	}
+
+	return null;
+}
+
+export function findItemTypeById(
+	itemTypes: any[],
+	itemTypeId: string | null | undefined,
+): NormalizedItemType | null {
+	if (itemTypeId == null || itemTypeId === "") {
+		return null;
+	}
+	const id = String(itemTypeId);
+	for (const entry of itemTypes) {
+		const normalized = normalizeItemTypeEntry(entry);
+		if (normalized && normalized.id === id) {
+			return normalized;
+		}
+	}
+	return null;
+}
+
 const Helpers = () => {
 	// Return parametes object form the current context (Ctx)
 	function getCtxParams(ctx: any, configType: string) {
@@ -53,6 +109,8 @@ const Helpers = () => {
 	return {
 		getCtxParams,
 		getDefaultValue,
+		normalizeItemTypeEntry,
+		findItemTypeById,
 	};
 };
 

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -10,7 +10,9 @@ export type NormalizedItemType = {
 	type?: string;
 };
 
-export function normalizeItemTypeEntry(itemType: any): NormalizedItemType | null {
+export function normalizeItemTypeEntry(
+	itemType: any,
+): NormalizedItemType | null {
 	if (!itemType) {
 		return null;
 	}


### PR DESCRIPTION


## Summary

After #17, the allowed record models stored in plugin parameters were switched to a compact shape (`{ label, api_key, value }`, where `value` is the item type id) to keep plugin parameters under DatoCMS's 10 KB limit. However, `FieldRecord` and `ContentConfigScreen` still looked up entries by `.id` (`itemTypes.find(it => it.id === itemTypeId)`), which silently no longer matches anything for installations saved on 0.2.6+.

In practice this meant the linked record's `modelApiKey` could not be resolved from the configured `itemTypes`, which in turn broke the slug/URL composition for the link preview.

This PR centralizes item type resolution behind a small normalization helper that understands both shapes, removes the now-redundant URL/`attributes` fallback paths, and leaves the public API of `Helpers()` backward compatible.

Should fix #19.

## Changes

- **`src/utils/helpers.tsx`**
  - Add `NormalizedItemType` type.
  - Add `normalizeItemTypeEntry(itemType)`: compact shape (post-0.2.7): `{ label, api_key?, value }` → `{ id: value, api_key, label }`; legacy full Dato item type resource: `{ id, attributes: { api_key, name, kind } }` → normalized fields; returns `null` for anything else.
  - Add `findItemTypeById(itemTypes, itemTypeId)` that normalizes on read and coerces both ids to strings before comparing.
  - Export both helpers from `Helpers()` alongside the existing API.
- **`src/components/fields/FieldRecord.tsx`**
  - Replace the inline `itemTypes.find(it => it.id === itemTypeId)` with `findItemTypeById(...)` so compact entries are matched correctly.
- **`src/entrypoints/ContentConfigScreen.tsx`**
  - `getRecordModel` now delegates to `findItemTypeById`.
  - `getRecordModelDetails` reads `api_key` directly off the normalized model and drops the `attributes.api_key` and `cms_url` regex fallbacks — those paths are no longer reachable now that normalization happens at lookup time.
  - Tighten optional chaining around the normalized model.

## Why this approach

- Keeps #17's payload size win intact — we don't reintroduce the full item type objects into plugin parameters.
- Preserves backward compatibility for plugin configurations saved before 0.2.7 (legacy shape still resolves via `normalizeItemTypeEntry`).
- Single source of truth for "given an id, give me an item type" — future call sites won't need to reinvent the shape detection.

## Test plan

- [ ] Fresh install: configure allowed models via `LinkSettings`, link a record, confirm the preview shows the correct model API key and slug.
- [ ] Edge cases: linked record whose `item_type` is no longer in the allowed list → no crash, falls back gracefully.

## Notes

- Second commit (`prettier`) is a formatting-only pass on `helpers.tsx`.
- No changes to plugin parameter schema or migrations required.